### PR TITLE
fix: Correctly handle 'HOLD' action from AI advisor

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -1731,7 +1731,7 @@ class Trader:
                 if confidence_pct is not None:
                     confidence = float(confidence_pct) / 100.0
 
-            if action not in ["long", "short", "skip"] or confidence is None:
+            if action not in ["long", "short", "skip", "hold"] or confidence is None:
                 print(f"AI Advisor returned invalid advice: action='{action}', conf={confidence}")
                 return None
 


### PR DESCRIPTION
The previous implementation incorrectly rejected 'HOLD' as a valid action from the AI advisory service, causing the application to log an 'invalid advice' error. This was due to 'hold' being omitted from the list of expected actions in the response validation logic.

This commit updates the validation list in `trading.py` to include 'hold' as a recognized action. This ensures the trading bot now correctly interprets and follows the AI's recommendation to hold, which is a critical instruction during periods of market uncertainty or when the AI is operating with stale context data, as was reported.

## Summary by Sourcery

Bug Fixes:
- Add 'hold' to the list of valid AI advisor actions to prevent HOLD being rejected as invalid