### PR TITLE
feat: Implement periodic AI bias analysis to reduce API calls

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
         "use_ai_overseer": true,
         "advisor_url": "https://chatgpt-scalper-1.onrender.com/advice",
         "advisor_auth_token": "Jules-AI-9876",
-        "advisor_min_confidence": 0.65
+        "advisor_min_confidence": 0.65,
+        "ai_analysis_interval_sec": 300
     }
 }

--- a/settings.py
+++ b/settings.py
@@ -41,6 +41,7 @@ class AISettings:
     advisor_auth_token: Optional[str] = None
     advisor_timeout_ms: int = 7000
     advisor_min_confidence: float = 0.65
+    ai_analysis_interval_sec: int = 300
 
 
 @dataclass
@@ -101,7 +102,8 @@ class Settings:
             advisor_url=ai_cfg.get("advisor_url"),
             advisor_auth_token=os.environ.get("ADVISOR_AUTH_TOKEN") or ai_cfg.get("advisor_auth_token"),
             advisor_timeout_ms=ai_cfg.get("advisor_timeout_ms", 7000),
-            advisor_min_confidence=ai_cfg.get("advisor_min_confidence", 0.65)
+            advisor_min_confidence=ai_cfg.get("advisor_min_confidence", 0.65),
+            ai_analysis_interval_sec=ai_cfg.get("ai_analysis_interval_sec", 300)
         )
 
         return Settings(openapi=openapi_settings, general=general_settings, ai=ai_settings)
@@ -140,7 +142,8 @@ class Settings:
                 "advisor_url": self.ai.advisor_url,
                 "advisor_auth_token": self.ai.advisor_auth_token if not os.environ.get("ADVISOR_AUTH_TOKEN") else None,
                 "advisor_timeout_ms": self.ai.advisor_timeout_ms,
-                "advisor_min_confidence": self.ai.advisor_min_confidence
+                "advisor_min_confidence": self.ai.advisor_min_confidence,
+                "ai_analysis_interval_sec": self.ai.ai_analysis_interval_sec
             }
         }
         with open(path, 'w') as f:


### PR DESCRIPTION
This commit refactors the AI integration to be more cost-effective. Instead of calling the AI advisor for every potential trade, the bot now periodically polls the AI for a general market bias ('long-only', 'short-only', or 'hold').

Key changes:
- A new setting, `ai_analysis_interval_sec`, has been added to control the frequency of AI analysis.
- The scalping loop in `gui.py` now triggers a periodic, threaded call to an `_update_ai_bias` method.
- This method gets a general market outlook from the AI and stores it. A new label on the UI displays the current AI bias.
- The trading strategy (`SafeStrategy`) has been updated to use this stored bias as a gatekeeper. It will only allow trades that align with the AI's current outlook, preventing trades when the bias is 'hold' or if the trade direction conflicts with the bias.
- The previous logic of calling the AI on every trade signal has been removed.

This change significantly reduces the number of API calls, lowering operational costs while retaining the benefits of AI-guided trading.

## Summary by Sourcery

Introduce scheduled AI market bias polling to reduce API calls and enforce bias-driven trade gating with UI feedback

New Features:
- Add ai_analysis_interval_sec setting to configure periodic AI analysis
- Implement background AI bias polling in the scalping loop
- Display AI bias and confidence in the GUI
- Gate SafeStrategy trades based on stored AI bias

Enhancements:
- Remove per-trade AI advisor calls to lower API usage